### PR TITLE
use deploy-pages

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,7 +5,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['main', 'feature/use-deploy-pages']
+    branches: ['main']
 
 permissions:
   contents: write

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          name: ./dist
+          path: ./dist
 
   deploy:
     needs: build

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,14 +5,15 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['main']
+    branches: ['main', 'feature/use-deploy-pages']
 
 permissions:
   contents: write
   pages: write
+  id-token: write
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,8 +27,19 @@ jobs:
 
       - name: Build with Vite
         run: bun run build --base=/cellpack-client
-
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: ./dist
+          name: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: 
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
Proposes switching to github's native `deploy-pages` action for github pages deployment.
closes #10 

The deployment in pr #12 is working well. After digging around, I found that github recommends using `deploy-pages` so I'm giving it a try.

Doc: https://github.com/marketplace/actions/deploy-github-pages-site

Solution
========
What I/we did to solve this problem
- Replaces `JamesIves/github-pages-deploy-action@v4` with `actions/deploy-pages@v4`

Pros:
- better integration with github environment protection rules 
- easier maintenance 

Cons:
- slightly more complex since it involves uploading artifacts and environment setup, etc.

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. this pr was tested by temporarily adding the working branch to protection rules
2. the workflow should work as expected after merging into `main`
