### PR TITLE
display grid file path if it's part of the recipe

### DIFF
--- a/src/recipeLoader.ts
+++ b/src/recipeLoader.ts
@@ -141,6 +141,7 @@ const recipeToViewable = (recipe: FirebaseRecipe): ViewableRecipe => {
         version: recipe.version,
         format_version: recipe.format_version,
         bounding_box: recipe.bounding_box,
+        grid_file_path: recipe.grid_file_path,
         composition: viewableComp,
         objects: viewableObj,
         gradients: viewableGradient,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,6 +116,7 @@ export interface FirebaseRecipe {
     version?: string;
     format_version?: string;
     bounding_box?: [][] | object;
+    grid_file_path?: string;
     recipe_path?: string;
     composition?: Dictionary<FirebaseComposition>;
     objects?: Dictionary<FirebaseObject>;
@@ -131,6 +132,7 @@ export type ViewableRecipe = {
     version?: string;
     format_version?: string;
     bounding_box?: [][] | object;
+    grid_file_path?: string;
     composition?: Dictionary<ViewableComposition>;
     objects?: Dictionary<ViewableObject>;
     gradients?: Dictionary<ViewableGradient>;


### PR DESCRIPTION
Problem
=======
We started testing a recipe that has a grid_file_path parameter, and although it shows up in firebase, it wasn't showing up on the UI

Solution
========
Add grid_file_path as one of the keys in our recipe types so it'll show up
