### PR TITLE
point to api gateway url instead of ecs instance ip address

### DIFF
--- a/src/constants/awsBatch.ts
+++ b/src/constants/awsBatch.ts
@@ -1,7 +1,7 @@
 //api endpoints
 const BASE_URL = "https://ng44ddk8v1.execute-api.us-west-2.amazonaws.com/testing";
 const SUBMIT_PACKING_BASE = `${BASE_URL}/submit-packing`;
-const SUBMIT_PACKING_ECS = "http://34.223.42.173:8443/pack";
+const SUBMIT_PACKING_ECS = "https://bda21vau5c.execute-api.us-west-2.amazonaws.com/staging/pack";
 const PACKING_STATUS_BASE = `${BASE_URL}/packing-status`;
 const GET_LOGS_BASE = `${BASE_URL}/logs`;
 


### PR DESCRIPTION
Problem
=======
Currently, the cellPACK client is hitting the ECS IP address directly for requests for ECS packings. This has 2 main issues for us in this prototype phase:
1. if we make any changes to the docker image and want to redeploy our ECS container, the IP address will change and our checked in code will no longer work
2. there are CORS issues with hitting the ECS container's IP address directly, so it wasn't actually working on the main cellPACK client site (and would only work locally if you manipulated CORS with a browser extension)

Solution
========
* Set up a basic Application Load Balancer in AWS that handles incoming traffic to the ECS container
* Created a new API Gateway API in AWS to route traffic to the load balancer and then to our IP address
* In the client repo, if we now point to the API Gateway endpoint, our above listed problems are solved!

* NOTE: I did have to make some small changes to the docker image to get the application load balancer to work, a PR for that will be incoming in the cellpack repo
