### PR TITLE
github action for generating pr preview link

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -27,26 +27,6 @@ jobs:
 
       - name: Build with Vite
         run: bun run build --base=/cellpack-client
-      
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          name: production-files
-          path: ./dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: production-files
-          path: ./dist
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -43,3 +43,5 @@ jobs:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          clean-exclude: pr-preview/

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -39,6 +39,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,7 +5,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['main', 'feature/pr-preview-link']
+    branches: ['main', 'feature/pr-preview-linkg']
 
 permissions:
   contents: write
@@ -31,17 +31,23 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
+          name: production-files
           path: ./dist
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment: 
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
-      - name: Deploy
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v4
         with:
+          name: production-files
+          path: ./dist
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: ./dist
           clean-exclude: pr-preview/
+          branch: gh-pages

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,7 +5,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['main', 'feature/pr-preview-link']
+    branches: ['main']
 
 permissions:
   contents: write

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,7 +5,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['main', 'feature/pr-preview-linkg']
+    branches: ['main', 'feature/pr-preview-link']
 
 permissions:
   contents: write

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,7 +5,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['main']
+    branches: ['main', 'feature/pr-preview-link']
 
 permissions:
   contents: write

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -25,9 +25,7 @@ jobs:
         run: bun install
 
       - name: Build with Vite
-        run: bun run build --base=/cellpack-client/pr-preview/pr-${PR_NUMBER}/
-        env:
-          PR_NUMBER: ${{ github.event.number }}
+        run: bun run build
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -25,10 +25,9 @@ jobs:
         run: bun install
 
       - name: Build with Vite
-        run: bun run build
+        run: bun run build --base=/cellpack-client
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./dist/
-          preview-branch: gh-pages

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -14,7 +14,6 @@ concurrency: preview-${{ github.ref }}
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
-    needs: [deploy-preview-internal]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -30,6 +30,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
 
       - name: Deploy preview
-        uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1
+        uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./dist/
+          preview-branch: gh-pages

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -26,9 +26,11 @@ jobs:
 
       - name: Build with Vite
         run: bun run build --base=/cellpack-client/pr-preview/pr-${PR_NUMBER}
-        run: echo "PR number - ${{ github.event.number }}"
         env:
           PR_NUMBER: ${{ github.event.number }}
+
+      - name: debug
+        run: echo "PR number - ${{ github.event.number }}"
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -25,7 +25,10 @@ jobs:
         run: bun install
 
       - name: Build with Vite
-        run: bun run build --base=/cellpack-client
+        run: bun run build --base=/cellpack-client/pr-preview/pr-${PR_NUMBER}
+        run: echo "PR number - ${{ github.event.number }}"
+        env:
+          PR_NUMBER: ${{ github.event.number }}
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -29,9 +29,6 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.number }}
 
-      - name: debug
-        run: echo "PR number - ${{ github.event.number }}"
-
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,36 @@
+# Adapted from https://github.com/marketplace/actions/deploy-pr-preview.
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    needs: [deploy-preview-internal]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install
+        run: bun install
+
+      - name: Build with Vite
+        run: bun run build --base=/cellpack-client/pr-preview/pr-${PR_NUMBER}/
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@430e3dfc1de8a8ae77e77d862d25676ef9db55d1
+        with:
+          source-dir: ./dist/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -222,9 +222,6 @@ function App() {
                         </option>
                     ))}
                 </select>
-                <button onClick={runPacking} disabled={!selectedRecipe}>
-                    Pack on Batch
-                </button>
                 <button onClick={runPackingECS} disabled={!selectedRecipe}>
                     Pack on ECS
                 </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,9 +127,6 @@ function App() {
     };
 
     const getLogs = async () => {
-        if (logStreamName === "") {
-            await runPacking();
-        }
         const url = getLogsUrl(logStreamName);
         const request: RequestInfo = new Request(
             url,
@@ -225,6 +222,9 @@ function App() {
                         </option>
                     ))}
                 </select>
+                <button onClick={runPacking} disabled={!selectedRecipe}>
+                    Pack on Batch
+                </button>
                 <button onClick={runPackingECS} disabled={!selectedRecipe}>
                     Pack on ECS
                 </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,6 +127,9 @@ function App() {
     };
 
     const getLogs = async () => {
+        if (logStreamName === "") {
+            await runPacking();
+        }
         const url = getLogsUrl(logStreamName);
         const request: RequestInfo = new Request(
             url,


### PR DESCRIPTION
Problem
=======
It would be good to have a PR preview link that is automatically generated when a cellpack-client PR is open for Thao to review for UX changes.

[Link to ticket](https://github.com/mesoscope/cellpack-client/issues/26)

Solution
========
* Did something similar to the PR preview GitHub action in the Timelapse Colorizer repo (see [here](https://github.com/allen-cell-animated/timelapse-colorizer/blob/main/.github/workflows/pr-preview.yml))
* To get the PR preview action to work, I had to change a Github Pages setting so that the source for deploying Pages would be from the gh-pages branch. This broke the main website Github Pages build / deploy action, so I had to change that to something that would be compatible with the same settings 

## Type of change
* New feature (non-breaking change which adds functionality)

