### PR TITLE
update server communication protocol to poll firebase for job status

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -63,3 +63,18 @@
   width: 450px;
   overflow-y: auto;
 }
+
+.logBox {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row;
+  text-align: start;
+  margin-top: 10px;
+  padding: 10px;
+  border-radius: 5px;
+  max-height: 300px;
+  overflow-y: auto;
+  font-size: 14px;
+  align-items: flex-start;
+  border: 1px solid #ddd;
+}

--- a/src/constants/awsBatch.ts
+++ b/src/constants/awsBatch.ts
@@ -1,33 +1,22 @@
 //api endpoints
-const BASE_URL = "https://ng44ddk8v1.execute-api.us-west-2.amazonaws.com/testing";
-const SUBMIT_PACKING_BASE = `${BASE_URL}/submit-packing`;
-const SUBMIT_PACKING_ECS = "https://bda21vau5c.execute-api.us-west-2.amazonaws.com/staging/pack";
-const PACKING_STATUS_BASE = `${BASE_URL}/packing-status`;
-const GET_LOGS_BASE = `${BASE_URL}/logs`;
+const SUBMIT_PACKING_ECS = "https://bda21vau5c.execute-api.us-west-2.amazonaws.com/production/start-packing";
 
 export const getSubmitPackingUrl = (
     recipe: string,
     config?: string,
-    useECS: boolean = false
 ) => {
-    const baseURL = useECS ? SUBMIT_PACKING_ECS : SUBMIT_PACKING_BASE;
-    let url = `${baseURL}?recipe=${recipe}`;
+    let url = `${SUBMIT_PACKING_ECS}?recipe=${recipe}`;
     if (config) {
         url += `&config=${config}`;
     }
     return url;
 }
 
-export const packingStatusUrl = (jobId: string) => `${PACKING_STATUS_BASE}?jobId=${jobId}`;
-export const getLogsUrl = (logStreamName: string) => `${GET_LOGS_BASE}?logStreamName=${logStreamName}`;
-
 //job status
 export enum JobStatus {
     SUBMITTED = "SUBMITTED",
-    PENDING = "PENDING",
-    RUNNABLE = "RUNNABLE",
     STARTING = "STARTING",
     RUNNING = "RUNNING",
-    SUCCEEDED = "SUCCEEDED",
+    DONE = "DONE",
     FAILED = "FAILED",
 }

--- a/src/constants/firebaseConstants.ts
+++ b/src/constants/firebaseConstants.ts
@@ -14,6 +14,7 @@ export const FIRESTORE_COLLECTIONS = {
     GRADIENTS: "gradients",
     COMPOSITION: "composition",
     EXAMPLE_RECIPES: "example_recipes",
+    JOB_STATUS: "job_status",
 };
 
 //firestore field names

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -54,6 +54,20 @@ const queryFirebase = async (jobId: string) => {
     return resultUrl;
 };
 
+const getJobStatus = async (jobId: string) => {
+    const q = query(
+        collection(db, FIRESTORE_COLLECTIONS.JOB_STATUS),
+        where(documentId(), "==", jobId)
+    );
+    const querySnapshot = await getDocs(q);
+    let status = "";
+    querySnapshot.forEach((doc) => {
+        // we'll only ever expect one doc to show up here
+        status = doc.data().status;
+    });
+    return status;
+}
+
 const getAllDocsFromCollection = async (collectionName: string) => {
     const q = query(collection(db, collectionName));
     const querySnapshot = await getDocs(q);
@@ -237,4 +251,4 @@ const getFirebaseRecipe = async (name: string): Promise<string> => {
     return unpackedRecipe;
 }
 
-export { db, queryFirebase, getLocationDict, getDocById, getFirebaseRecipe };
+export { db, queryFirebase, getLocationDict, getDocById, getFirebaseRecipe, getJobStatus };


### PR DESCRIPTION
Problem
=======
We changed some things on the server side, so here are the corresponding changes on the client side!
[Link to Server PR](https://github.com/mesoscope/cellpack/pull/345)

[Link to story or ticket](https://github.com/mesoscope/cellpack-client/issues/29)

Solution
========
* The [Server PR](https://github.com/mesoscope/cellpack/pull/345) talks in detail about the communication protocol changes, but here's the quick summary. Currently, the client sends a single request to the server to run a packing, and does not get a response until that packing is either done or failed. With this PR, the client sends a request to start a packing, and the server responds immediately with a job ID. Then, the client will continuously check firebase for job updates for that job ID until the job eventually succeeds or fails.
* I also removed the "Run in Batch" button and the related batch stuff. We aren't going to be using batch going forward for this version of the client, so I think it's time to get rid of it.