### PR TITLE
Make Edited Recipe Result File Names Unique

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,13 +43,14 @@ function App() {
         return !(originalRecipe == recipeStr);
     }
 
-    const recipeToFirebase = (recipe: string, path: string): object => {
+    const recipeToFirebase = (recipe: string, path: string, id: string): object => {
         const recipeJson = JSON.parse(recipe);
         if (recipeJson.bounding_box) {
             let flattened_array = Object.assign({}, recipeJson.bounding_box);
             recipeJson.bounding_box = flattened_array;
         }
         recipeJson[FIRESTORE_FIELDS.RECIPE_PATH] = path;
+        recipeJson[FIRESTORE_FIELDS.NAME] = id;
         return recipeJson;
     }
 
@@ -62,7 +63,7 @@ function App() {
         if (recipeChanged) {
             const recipeId = uuidv4();
             firebaseRecipe = "firebase:recipes_edited/" + recipeId;
-            const recipeJson = recipeToFirebase(recipeStr, firebaseRecipe);
+            const recipeJson = recipeToFirebase(recipeStr, firebaseRecipe, recipeId);
             try {
                 await updateRecipe(recipeId, recipeJson);
             } catch(e) {


### PR DESCRIPTION
Problem
=======
There is a bug where edited recipes will produce result files that will overwrite each other in s3 unless the "name" field is edited. 
[Link to story or ticket](https://github.com/mesoscope/cellpack-client/issues/42)

Solution
========
Set "name" to the unique generated recipe ID for edited recipes. This name will be used in creating the result .simularium file name when the packing runs, so thus the result file name will be unique as well!
