### PR TITLE
keep name fields visible in recipe json

### DIFF
--- a/src/recipeLoader.ts
+++ b/src/recipeLoader.ts
@@ -117,19 +117,19 @@ const resolveRefsInComposition = (
 
 const stripFirebaseFields = <T extends { name: string; id: string; dedup_hash: string }>(
     obj: T
-): Omit<T, "name" | "id" | "dedup_hash"> => {
-    const { name, id, dedup_hash, ...viewable } = obj;
-    void name; void id; void dedup_hash; // Tell linter these are intentionally unused, we are "using" them by excluding them
-    return viewable as Omit<T, "name" | "id" | "dedup_hash">;
+): Omit<T, "id" | "dedup_hash"> => {
+    const { id, dedup_hash, ...viewable } = obj;
+    void id; void dedup_hash; // Tell linter these are intentionally unused, we are "using" them by excluding them
+    return viewable as Omit<T, "id" | "dedup_hash">;
 };
 
 // reusable function for converting a collection of Firebase objects to a viewable format)
 const convertCollectionToViewable = <T extends { name: string; id: string; dedup_hash: string }>(
     collection: Dictionary<T> | undefined
-): Dictionary<Omit<T, "name" | "id" | "dedup_hash">> => {
+): Dictionary<Omit<T, "id" | "dedup_hash">> => {
     if (!collection) return {};
 
-    const viewableCollection: Dictionary<Omit<T, "name" | "id" | "dedup_hash">> = {};
+    const viewableCollection: Dictionary<Omit<T, "id" | "dedup_hash">> = {};
     for (const key in collection) {
         viewableCollection[key] = stripFirebaseFields(collection[key]);
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -123,7 +123,7 @@ export interface FirebaseRecipe {
     gradients?: Dictionary<FirebaseGradient>;
 };
 
-export type Viewable<T extends { name: string; id: string; dedup_hash: string }> = Omit<T, "name" | "id" | "dedup_hash">;
+export type Viewable<T extends { id: string; dedup_hash: string }> = Omit<T, "id" | "dedup_hash">;
 
 export type ViewableComposition = Viewable<FirebaseComposition>;
 export type ViewableObject = Viewable<FirebaseObject>;


### PR DESCRIPTION
Problem
=======
Currently, there's a bug when you try to edit a recipe that has gradients. This is because the gradient's name field has been removed during the process of forming the JSON object from the nested firebase references, and we aren't adding it back in when we upload the edited recipe to the recipes_edited firebase collection. The cellPACK python package expects each gradient to have name field present, so it throws an error.

Solution
========
While I originally removed the "name" field from gradients, objects, and compositions for displaying in the JSON, along with "id" and "dedup_hash", because that information seemed unnecessary / redundant, I now think we should keep the "name" field displayed. 

I originally added "name" back just to solve this bug, but fundamentally I think we should include "name" in general. While "dedup_hash" and "id" are firebase fields that the user really doesn't need to see, "name" is an expected field by cellpack, and if the user were to run a recipe locally, they would need to have the "name" field present. Thus, I think we should display it in the recipe JSON, so the user has an accurate representation of what is being run.

To Test
========
Go to the preview link, select the `ER_peroxisome` recipe and the `rules_shape` config, then make a change to the recipe. The packing should run and work as expected (previously, it would have failed)