### PR TITLE
add run linter step before build with vite

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install
         run: bun install
 
+      - name: Run Linter
+        run: bun run lint
+
       - name: Build with Vite
         run: bun run build --base=/cellpack-client/pr-preview/pr-${PR_NUMBER}
         env:


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #53 

Solution
========
What I/we did to solve this problem
This turns out to be a simple change! The lint script is already exist in package.json, and the workflow `pr-preview.yml` already handles build and deploy. I just added a step to run linter before the build, and it works! 

we're using ESLint flat config in `eslint.config.js`, so we can customize the rules as needed. 


<img width="576" height="113" alt="Screenshot 2025-08-04 at 3 32 11 PM" src="https://github.com/user-attachments/assets/c555f2dc-6d44-4c0b-b286-f906750e453f" />



## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)
