### PR TITLE
Hide Config

### DIFF
--- a/src/components/JSONViewer/style.css
+++ b/src/components/JSONViewer/style.css
@@ -1,7 +1,8 @@
 .recipe-json {
   max-height: 300px;
   width: 450px;
-  overflow-y: auto;}
+  overflow-y: auto;
+}
 
 .collapsible {
   width: 450px;

--- a/src/components/JSONViewer/style.css
+++ b/src/components/JSONViewer/style.css
@@ -1,24 +1,7 @@
-.recipe-box {
-  width: 45%;
-  float: left;
-}
-
-.config-box {
-  width: 45%;
-  float: right;
-}
-
 .recipe-json {
   max-height: 300px;
   width: 450px;
-  overflow-y: auto;
-}
-
-.config-json {
-  max-height: 300px;
-  width: 450px;
-  overflow-y: auto;
-}
+  overflow-y: auto;}
 
 .collapsible {
   width: 450px;

--- a/src/components/PackingInput/style.css
+++ b/src/components/PackingInput/style.css
@@ -1,6 +1,5 @@
 .box {
   display: flex;
-  justify-content: space-between;
-  flex-direction: row;
-  text-align: start;
+  justify-content: center;
+  align-items: center;
 }

--- a/src/constants/firebase.ts
+++ b/src/constants/firebase.ts
@@ -16,6 +16,7 @@ export const FIRESTORE_COLLECTIONS = {
     EXAMPLE_RECIPES: "example_recipes",
     EDITED_RECIPES: "recipes_edited",
     JOB_STATUS: "job_status",
+    PACKING_INPUTS: "example_packings",
 };
 
 //firestore field names
@@ -34,6 +35,8 @@ export const FIRESTORE_FIELDS = {
     URL: "url",
     STATUS: "status",
     TIMESTAMP: "timestamp",
+    RECIPE: "recipe",
+    CONFIG: "config",
 } as const;
 
 export const RETENTION_POLICY = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,8 @@ export interface Document {
     name?: string;
     original_location?: string;
     recipe_path?: string;
+    recipe?: string;
+    config?: string;
 }
 
 export type FirestoreDoc = Document & {
@@ -29,6 +31,11 @@ export type FirebaseDict = {
 
 export interface Dictionary<T> {
     [Key: string]: T;
+}
+
+export type PackingInputs = {
+    config: string;
+    recipe: string;
 }
 
 export interface RefsByCollection {

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -122,9 +122,6 @@ const getAllDocsFromCollection = async (collectionName: string) => {
 
 const getPackingInputsDict = async () => {
     const docs = await getAllDocsFromCollection(FIRESTORE_COLLECTIONS.PACKING_INPUTS);
-    // docs is an array of objects, each with an id, a name, and other fields
-    // we want to create a dictionary with the name as the key and the original_location as the value
-    // `reduce` is a method that takes an array and reduces it to a single value
     const inputsDict: Dictionary<PackingInputs> = docs.reduce((inputsDict: Dictionary<PackingInputs>, doc: FirestoreDoc) => {
         const name = doc[FIRESTORE_FIELDS.NAME];
         const config = doc[FIRESTORE_FIELDS.CONFIG];
@@ -136,7 +133,7 @@ const getPackingInputsDict = async () => {
             };
         }
         return inputsDict;
-    }, {} as Dictionary<PackingInputs>);
+    }, {});
     return inputsDict;
 }
 

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -22,6 +22,8 @@ import {
 import {
     FirebaseDict,
     FirestoreDoc,
+    PackingInputs,
+    Dictionary,
 } from "../types";
 
 const getEnvVar = (key: string): string => {
@@ -119,22 +121,24 @@ const getAllDocsFromCollection = async (collectionName: string) => {
     return mapQuerySnapshotToDocs(querySnapshot);
 };
 
-const getLocationDict = async (collectionName: string) => {
-    const docs = await getAllDocsFromCollection(collectionName);
+const getPackingInputsDict = async () => {
+    const docs = await getAllDocsFromCollection(FIRESTORE_COLLECTIONS.PACKING_INPUTS);
     // docs is an array of objects, each with an id, a name, and other fields
     // we want to create a dictionary with the name as the key and the original_location as the value
     // `reduce` is a method that takes an array and reduces it to a single value
-    const locationDict = docs.reduce((locationDict: FirebaseDict, doc: FirestoreDoc) => {
+    const inputsDict: Dictionary<PackingInputs> = docs.reduce((inputsDict: Dictionary<PackingInputs>, doc: FirestoreDoc) => {
         const name = doc[FIRESTORE_FIELDS.NAME];
-        const id = doc.id;
-        if (name) {
-            locationDict[name] = {
-                [FIRESTORE_FIELDS.FIREBASE_ID]: id,
+        const config = doc[FIRESTORE_FIELDS.CONFIG];
+        const recipe = doc[FIRESTORE_FIELDS.RECIPE];
+        if (name && config && recipe) {
+            inputsDict[name] = {
+                [FIRESTORE_FIELDS.CONFIG]: config,
+                [FIRESTORE_FIELDS.RECIPE]: recipe,
             };
-        } 
-        return locationDict;
-    }, {} as FirebaseDict);
-    return locationDict;
+        }
+        return inputsDict;
+    }, {} as Dictionary<PackingInputs>);
+    return inputsDict;
 }
 
 const getDocById = async (coll: string, id: string) => {
@@ -184,4 +188,4 @@ const docCleanup = async () => {
         console.log(`Cleaned up ${deletePromises.length} documents from ${collectionConfig.name}`);
     }
 }
-export { db, queryDocumentById, getLocationDict, getDocById, getDocsByIds, getJobStatus, getResultPath, addRecipe, docCleanup };
+export { db, queryDocumentById, getDocById, getDocsByIds, getJobStatus, getResultPath, addRecipe, docCleanup, getPackingInputsDict };

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -20,7 +20,6 @@ import {
     RETENTION_POLICY,
 } from "../constants/firebase";
 import {
-    FirebaseDict,
     FirestoreDoc,
     PackingInputs,
     Dictionary,


### PR DESCRIPTION
Problem
=======
We don't want the users manually selecting their configs, we can do that for them
[Link to story or ticket](https://github.com/mesoscope/cellpack-client/issues/69)

Solution
========
* Created a new collection in firebase, called `example_packings`, where each entry contains the ID of a recipe that's in the recipes collection, the ID of a config that's in the configs collection, and a human readable name. These together represent one entity that can be selected as the inputs to a packing on the cellpack client
* Adjusted the cellpack client code so now the "select a recipe" drop down uses the names in the `example_packings` collection. When a user selects one of those options, the associated recipe ID and config ID are tracked and submitted when a user hits submit
* Removed the display of config selection and config JSON
* Minor formatting changes since we now only have one JSON object being displayed

