### PR TITLE
make keys actually unique

### DIFF
--- a/src/components/PackingInput/index.tsx
+++ b/src/components/PackingInput/index.tsx
@@ -121,7 +121,7 @@ const PackingInput = (props: PackingInputProps): JSX.Element => {
                             <h3>Options</h3>
                             {fieldsToDisplay.map((field) => (
                                 <InputSwitch
-                                    key={field.path}
+                                    key={field.id}
                                     displayName={field.name}
                                     inputType={field.input_type}
                                     dataType={field.data_type}

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,7 @@ export type PackingInputs = {
 }
 
 export type EditableField = {
+    id: string;
     name: string;
     data_type: string;
     input_type: string;


### PR DESCRIPTION
Problem
=======
I noticed some buggy behavior in the viewer when changing between different recipes. After fumbling around in react, I learned it was because the "key" field is very important and we were having overlapping values when we were setting it to the Editable Field's path (because multiple recipes had "objects.endosome.radius", for example)

To fix this, we now set "key" to the firebase ID, which is actually unique to each editable field!

@interim17 helped me debug and the client site was rendering very dark for him, and he traced it down to the background color set in index.css, so that's getting changed in this PR too.