### PR TITLE
Prototype: Minimize Firebase Calls by Holding Recipe Data

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -5,10 +5,11 @@ interface DropdownProps {
     placeholder: string;
     options: Dictionary<PackingInputs>;
     onChange: (value: string) => void;
+    loading?: boolean;
 }
 
 const Dropdown = (props: DropdownProps): JSX.Element => {
-    const { placeholder, options, onChange } = props;
+    const { placeholder, options, onChange, loading } = props;
     const selectOptions = Object.entries(options).map(([key]) => (
         {
             label: <span>{key}</span>,
@@ -20,9 +21,10 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
         <Select
             defaultValue={undefined}
             onChange={onChange}
-            placeholder={placeholder}
+            placeholder={loading ? "Loading..." : placeholder}
             options={selectOptions}
             style={{ width: "100%", paddingLeft: 5 }}
+            disabled={loading}
         />
     );
 };

--- a/src/components/PackingInput/index.tsx
+++ b/src/components/PackingInput/index.tsx
@@ -55,7 +55,7 @@ const PackingInput = (props: PackingInputProps): JSX.Element => {
     const handleFormChange = (changes: Dictionary<string | number>) => {
         if (!selectedInput) return;
 
-        const recObj = selectedInput.currentRecipeObj;
+        const recObj: any = selectedInput.currentRecipeObj;
         for (const [id, value] of Object.entries(changes)) {
             const keys = id.split('.');
             let current = recObj;
@@ -84,7 +84,7 @@ const PackingInput = (props: PackingInputProps): JSX.Element => {
         if (!selectedInput) return undefined;
 
         const keys = path.split('.');
-        let current = selectedInput.currentRecipeObj;
+        let current: any = selectedInput.currentRecipeObj;
         for (let i = 0; i < keys.length; i++) {
             const key = keys[i];
             if (current[key] === undefined) {

--- a/src/components/PackingInput/index.tsx
+++ b/src/components/PackingInput/index.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { PackingContext } from "../../context";
-import { Dictionary, EditableField, PackingInputs } from "../../types";
-import { getPackingInputsDict } from "../../utils/firebase";
-import { getFirebaseRecipe, jsonToString } from "../../utils/recipeLoader";
+import { Dictionary, PackingInputs } from "../../types";
+import { getPackingInputsDict } from "../../utils/recipeLoader";
+import { jsonToString } from "../../utils/recipeLoader";
 import Dropdown from "../Dropdown";
 import JSONViewer from "../JSONViewer";
 import RecipeForm from "../RecipeForm";
@@ -16,44 +16,49 @@ interface PackingInputProps {
 
 const PackingInput = (props: PackingInputProps): JSX.Element => {
     const { startPacking, submitEnabled } = props;
-    const [selectedRecipeId, setSelectedRecipeId] = useState("");
-    const [selectedConfigId, setSelectedConfigId] = useState("");
+    const [selectedInput, setSelectedInput] = useState<PackingInputs | undefined>(undefined);
     const [inputOptions, setInputOptions] = useState<Dictionary<PackingInputs>>({});
+    const [recipesLoading, setRecipesLoading] = useState<boolean>(true);
     const [recipeStr, setRecipeStr] = useState<string>("");
-    const [fieldsToDisplay, setFieldsToDisplay] = useState<EditableField[] | undefined>(undefined);
 
     useEffect(() => {
         const fetchData = async () => {
+            setRecipesLoading(true);
             const inputDict = await getPackingInputsDict();
             setInputOptions(inputDict);
+            setRecipesLoading(false);
         };
         fetchData();
     }, []);
 
     const selectInput = async (inputName: string) => {
-        const recipeId: string = inputOptions[inputName]?.recipe || "";
-        const configId: string = inputOptions[inputName]?.config || "";
-        setFieldsToDisplay(inputOptions[inputName]?.editable_fields || undefined);
-        await selectRecipe(recipeId);
-        setSelectedConfigId(configId);
-    }
+        if (!inputOptions[inputName]) return;
 
-    const selectRecipe = async (recipeId: string) => {
-        setSelectedRecipeId(recipeId);
-        const recJson = await getFirebaseRecipe(recipeId);
-        const recStr = jsonToString(recJson);
-        setRecipeStr(recStr);
-    }
+        // Reset current recipe to deep copy of initial recipe when switching inputs
+        setSelectedInput({
+            ...inputOptions[inputName],
+            currentRecipeObj: JSON.parse(JSON.stringify(inputOptions[inputName].initialRecipeObj))
+        });
+
+        const recString = jsonToString(inputOptions[inputName].initialRecipeObj);
+        console.log("Setting recipe string to: ", recString);
+        setRecipeStr(recString);
+    };
 
     const runPacking = async () => {
-        startPacking(selectedRecipeId, selectedConfigId, recipeStr);
+        if (!selectedInput) return;
+
+        const recString = jsonToString(selectedInput.currentRecipeObj);
+        startPacking(selectedInput.recipeId, selectedInput.configId, recString);
     };
 
     const handleFormChange = (changes: Dictionary<string | number>) => {
-        const recipeObj = JSON.parse(recipeStr);
+        if (!selectedInput) return;
+
+        const recObj = selectedInput.currentRecipeObj;
         for (const [id, value] of Object.entries(changes)) {
             const keys = id.split('.');
-            let current = recipeObj;
+            let current = recObj;
             for (let i = 0; i < keys.length; i++) {
                 const key = keys[i];
 
@@ -71,14 +76,15 @@ const PackingInput = (props: PackingInputProps): JSX.Element => {
                 }
             }
         }
-        const updatedRecipeStr = JSON.stringify(recipeObj, null, 2);
-        setRecipeStr(updatedRecipeStr);
+        setSelectedInput( { ...selectedInput, currentRecipeObj: recObj })
+        setRecipeStr(jsonToString(recObj));
     };
 
     const getCurrentValue = (path: string): string | number | undefined => {
-        const recipeObj = JSON.parse(recipeStr);
+        if (!selectedInput) return undefined;
+
         const keys = path.split('.');
-        let current = recipeObj;
+        let current = selectedInput.currentRecipeObj;
         for (let i = 0; i < keys.length; i++) {
             const key = keys[i];
             if (current[key] === undefined) {
@@ -89,13 +95,23 @@ const PackingInput = (props: PackingInputProps): JSX.Element => {
         return current;
     }
 
+    const updateRecipeStr = (newStr: string) => {
+        if (!selectedInput) return;
+        try {
+            const newObj = JSON.parse(newStr);
+            setSelectedInput( { ...selectedInput, currentRecipeObj: newObj } )
+            setRecipeStr(newStr);
+        } catch (e) {
+            console.error("Invalid JSON string: ", e);
+            setRecipeStr(newStr);
+            return;
+        }
+    }
+
     return (
         <div>
             <PackingContext.Provider value={{
-                recipeId: selectedRecipeId,
-                configId: selectedConfigId,
-                recipeString: recipeStr,
-                fieldsToDisplay: fieldsToDisplay,
+                selectedInput: selectedInput,
                 submitPacking: runPacking,
                 changeHandler: handleFormChange,
                 getCurrentValue: getCurrentValue
@@ -106,14 +122,15 @@ const PackingInput = (props: PackingInputProps): JSX.Element => {
                         placeholder="Select an option"
                         options={inputOptions}
                         onChange={selectInput}
+                        loading={recipesLoading}
                     />
                 </div>
                 <div className="recipe-content">
                     <JSONViewer
                         title="Recipe"
                         content={recipeStr}
-                        isEditable={fieldsToDisplay === undefined}
-                        onChange={setRecipeStr}
+                        isEditable={selectedInput?.editableFields === undefined}
+                        onChange={updateRecipeStr}
                     />
                     <RecipeForm submitEnabled={submitEnabled} />
                 </div>

--- a/src/components/RecipeForm/index.tsx
+++ b/src/components/RecipeForm/index.tsx
@@ -10,13 +10,14 @@ interface RecipeFormProps {
 
 const RecipeForm = (props: RecipeFormProps): JSX.Element => {
     const { submitEnabled } = props;
-    const { recipeId, fieldsToDisplay, submitPacking } = useContext(PackingContext);
+    const { selectedInput, submitPacking } = useContext(PackingContext);
+
     return (
         <div className="recipe-form">
-            {fieldsToDisplay && (
+            {selectedInput?.editableFields && (
                 <div className="input-container">
                     <h3>Options</h3>
-                    {fieldsToDisplay.map((field) => (
+                    {selectedInput.editableFields.map((field) => (
                         <InputSwitch
                             key={field.id}
                             displayName={field.name}
@@ -33,7 +34,7 @@ const RecipeForm = (props: RecipeFormProps): JSX.Element => {
                     ))}
                 </div>
             )}
-            { recipeId && (
+            { selectedInput && (
                 <Button
                     onClick={submitPacking}
                     color="primary"

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,21 +1,15 @@
 import { createContext } from "react";
-import { Dictionary, EditableField } from "./types";
+import { Dictionary, PackingInputs } from "./types";
 
 interface PackingContextType {
-    recipeId: string;
-    configId: string;
-    recipeString: string;
-    fieldsToDisplay?: EditableField[];
+    selectedInput: PackingInputs | undefined,
     changeHandler: (updates: Dictionary<string | number>) => void;
     getCurrentValue: (path: string) => string | number | undefined;
     submitPacking: () => Promise<void>;
 };
 
 export const PackingContext = createContext<PackingContextType>({
-    recipeId: "",
-    configId: "",
-    recipeString: "",
-    fieldsToDisplay: undefined,
+    selectedInput: undefined,
     changeHandler: async () => {},
     getCurrentValue: () => undefined,
     submitPacking: async () => {},

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,9 +35,11 @@ export interface Dictionary<T> {
 }
 
 export type PackingInputs = {
-    config: string;
-    recipe: string;
-    editable_fields?: EditableField[];
+    configId: string;
+    recipeId: string;
+    initialRecipeObj: ViewableRecipe;
+    currentRecipeObj: ViewableRecipe;
+    editableFields?: EditableField[];
 }
 
 export type EditableField = {

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -19,12 +19,7 @@ import {
     FIRESTORE_FIELDS,
     RETENTION_POLICY,
 } from "../constants/firebase";
-import {
-    FirestoreDoc,
-    PackingInputs,
-    Dictionary,
-    EditableField,
-} from "../types";
+import { FirestoreDoc } from "../types";
 
 const getEnvVar = (key: string): string => {
     // check if we're in a browser environment (Vite)
@@ -126,46 +121,6 @@ const getAllDocsFromCollection = async (collectionName: string) => {
     return mapQuerySnapshotToDocs(querySnapshot);
 };
 
-const getEditableFieldsList = async (editable_field_ids: string[]): Promise<EditableField[]|undefined> => {
-    if (editable_field_ids.length === 0) {
-        return undefined;
-    }
-    const querySnapshot = await queryDocumentsByIds(FIRESTORE_COLLECTIONS.EDITABLE_FIELDS, editable_field_ids);
-    const docs = querySnapshot.docs.map((doc) => ({
-        id: doc.id,
-        name: doc.data().name,
-        data_type: doc.data().data_type,
-        input_type: doc.data().input_type,
-        description: doc.data().description,
-        default: doc.data().default,
-        min: doc.data().min,
-        max: doc.data().max,
-        options: doc.data().options,
-        gradient_options: doc.data().gradient_options,
-        path: doc.data().path,
-    }));
-    return docs;
-};
-
-const getPackingInputsDict = async (): Promise<Dictionary<PackingInputs>> => {
-    const docs = await getAllDocsFromCollection(FIRESTORE_COLLECTIONS.PACKING_INPUTS);
-    const inputsDict: Dictionary<PackingInputs> = {};
-    for (const doc of docs) {
-        const name = doc[FIRESTORE_FIELDS.NAME];
-        const config = doc[FIRESTORE_FIELDS.CONFIG];
-        const recipe = doc[FIRESTORE_FIELDS.RECIPE];
-        const editableFields = await getEditableFieldsList(doc[FIRESTORE_FIELDS.EDITABLE_FIELDS] || []);
-        if (name && config && recipe) {
-            inputsDict[name] = {
-                [FIRESTORE_FIELDS.CONFIG]: config,
-                [FIRESTORE_FIELDS.RECIPE]: recipe,
-                [FIRESTORE_FIELDS.EDITABLE_FIELDS]: editableFields
-            };
-        }
-    }
-    return inputsDict;
-}
-
 const getDocById = async (coll: string, id: string) => {
     const docs = await getAllDocsFromCollection(coll);
     const doc = docs.find(d => d.id === id);
@@ -213,4 +168,4 @@ const docCleanup = async () => {
         console.log(`Cleaned up ${deletePromises.length} documents from ${collectionConfig.name}`);
     }
 }
-export { db, queryDocumentById, getDocById, getDocsByIds, getJobStatus, getResultPath, addRecipe, docCleanup, getPackingInputsDict, getOutputsDirectory };
+export { db, queryDocumentById, getDocById, getDocsByIds, getJobStatus, getResultPath, addRecipe, docCleanup, getAllDocsFromCollection, getOutputsDirectory, queryDocumentsByIds };


### PR DESCRIPTION
* Instead of querying firebase whenever we select a recipe, do all the querying on page load
* This makes it take a little longer for the dropdown options to populate, so add a "loading" option for the dropdown
* Save 2 copies of the each recipe object, so we can clear the current set of edits when desired (currently, whenever someone selects a new recipe)
* Update to PackingInput type to hold on to these recipe objects. I also changed the react context to pass the PackingInput object itself, instead of all it's fields. Not sure if that's better or worse from a react state management perspective... but it made things easier for me to understand