### PR TITLE
Feature/dark mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -55,8 +55,3 @@
   height: auto;
   min-height: 48px;
 }
-
-.footer {
-  height: 128px;
-  width: 100%;
-}

--- a/src/App.css
+++ b/src/App.css
@@ -12,8 +12,6 @@
 }
 
 .header {
-  color: #000000E0;
-  background-color: #ffffff;
   width: 90vw;
   display: flex;
   align-items: center;
@@ -60,6 +58,5 @@
 
 .footer {
   height: 128px;
-  background-color: #ffffff;
   width: 100%;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import PackingInput from "./components/PackingInput";
 import Viewer from "./components/Viewer";
 import ErrorLogs from "./components/ErrorLogs";
 
-const { Header, Content, Footer } = Layout;
+const { Header, Content } = Layout;
 const { Link } = Typography;
 
 function App() {
@@ -161,7 +161,6 @@ function App() {
                 {showLogs && <ErrorLogs errorLogs={jobLogs} getLogs={getLogs} />}
             </Content>
             {resultUrl && <Viewer resultUrl={resultUrl} />}
-            <Footer className="footer" />
         </div>
     );
 }

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -7,7 +7,7 @@ interface ViewerProps {
 const Viewer = (props: ViewerProps): JSX.Element => {
     const { resultUrl } = props;
     return (
-        <div>
+        <div className="viewer-container">
             <iframe className="simularium-embed" src={resultUrl} />
         </div>
     );

--- a/src/components/Viewer/style.css
+++ b/src/components/Viewer/style.css
@@ -1,3 +1,7 @@
+.viewer-container {
+    margin-bottom: 128px;
+}
+
 .simularium-embed {
     width: 1000px;
     height: 600px;

--- a/src/index.css
+++ b/src/index.css
@@ -4,8 +4,6 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -15,9 +13,7 @@
 
 body {
   margin: 0;
-  display: flex;
-  min-width: 320px;
-  min-height: 100vh;
+  display: block;
 }
 
 button {
@@ -27,7 +23,6 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -37,17 +32,4 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom"
 import './index.css'
 import App from './App.tsx'
 import { decodeGitHubPagesUrl, isEncodedPathUrl, tryRemoveHashRouting } from "./utils/gh_routing";
+import { ThemeRoot } from './style/themeRoot.tsx'
 
 // Decode URL path if it was encoded for GitHub pages or uses hash routing.
 const locationUrl = new URL(window.location.toString());
@@ -32,8 +33,10 @@ const router = createBrowserRouter(
   { basename: import.meta.env.BASE_URL }
 );
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <RouterProvider router={router} />
-  </StrictMode>,
-)
+createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+        <ThemeRoot>
+            <RouterProvider router={router} />
+        </ThemeRoot>
+    </StrictMode>
+);

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -1,0 +1,83 @@
+// theme.ts
+import type { ThemeConfig } from "antd";
+import { theme } from "antd"; // algorithms
+
+export const lightTheme: ThemeConfig = {
+    algorithm: theme.defaultAlgorithm,
+    token: {
+        // Brand + base
+        colorPrimary: "#646cff",
+        colorInfo: "#646cff",
+        fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+        borderRadius: 8,
+
+        // Surface & text to match your CSS defaults
+        colorBgBase: "#ffffff",
+        colorTextBase: "#213547",
+
+        // Subtle tweaks
+        controlHeight: 36,
+        wireframe: false,
+    },
+    components: {
+        Button: {
+            // match your button rounding & subtle borders
+            borderRadius: 8,
+            controlHeight: 40,
+        },
+        Layout: {
+            headerBg: "#ffffff",
+            bodyBg: "#ffffff",
+            footerBg: "#ffffff",
+        },
+        Card: {
+            borderRadiusLG: 12,
+        },
+        Modal: {
+            borderRadiusLG: 12,
+        },
+        Input: {
+            borderRadius: 8,
+        },
+        Select: {
+            borderRadius: 8,
+        },
+        Slider: {
+            handleSize: 12,
+            trackBg: "#646cff",
+        },
+    },
+};
+
+export const darkTheme: ThemeConfig = {
+    algorithm: theme.darkAlgorithm,
+    token: {
+        colorPrimary: "#8b91ff",
+        colorInfo: "#8b91ff",
+        fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+        borderRadius: 8,
+
+        // Dark surfaces & readable text
+        colorBgBase: "#0f1115",
+        colorTextBase: "rgba(255,255,255,0.87)",
+
+        controlHeight: 36,
+        wireframe: false,
+    },
+    components: {
+        Layout: {
+            headerBg: "#0f1115",
+            bodyBg: "#0f1115",
+            footerBg: "#0f1115",
+        },
+        Card: {
+            borderRadiusLG: 12,
+        },
+        Modal: {
+            borderRadiusLG: 12,
+        },
+        Slider: {
+            handleSize: 12,
+        },
+    },
+};

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -1,50 +1,25 @@
 // theme.ts
 import type { ThemeConfig } from "antd";
-import { theme } from "antd"; // algorithms
+import { theme } from "antd";
+
+const commonComponents = {
+    Button: { controlHeight: 40 },
+};
 
 export const lightTheme: ThemeConfig = {
     algorithm: theme.defaultAlgorithm,
     token: {
-        // Brand + base
         colorPrimary: "#646cff",
-        colorInfo: "#646cff",
         fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
         borderRadius: 8,
-
-        // Surface & text to match your CSS defaults
         colorBgBase: "#ffffff",
         colorTextBase: "#213547",
-
-        // Subtle tweaks
-        controlHeight: 36,
-        wireframe: false,
     },
     components: {
-        Button: {
-            // match your button rounding & subtle borders
-            borderRadius: 8,
-            controlHeight: 40,
-        },
+        ...commonComponents,
         Layout: {
             headerBg: "#ffffff",
             bodyBg: "#ffffff",
-            footerBg: "#ffffff",
-        },
-        Card: {
-            borderRadiusLG: 12,
-        },
-        Modal: {
-            borderRadiusLG: 12,
-        },
-        Input: {
-            borderRadius: 8,
-        },
-        Select: {
-            borderRadius: 8,
-        },
-        Slider: {
-            handleSize: 12,
-            trackBg: "#646cff",
         },
     },
 };
@@ -53,31 +28,16 @@ export const darkTheme: ThemeConfig = {
     algorithm: theme.darkAlgorithm,
     token: {
         colorPrimary: "#8b91ff",
-        colorInfo: "#8b91ff",
         fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
         borderRadius: 8,
-
-        // Dark surfaces & readable text
         colorBgBase: "#0f1115",
         colorTextBase: "rgba(255,255,255,0.87)",
-
-        controlHeight: 36,
-        wireframe: false,
     },
     components: {
+        ...commonComponents,
         Layout: {
             headerBg: "#0f1115",
             bodyBg: "#0f1115",
-            footerBg: "#0f1115",
-        },
-        Card: {
-            borderRadiusLG: 12,
-        },
-        Modal: {
-            borderRadiusLG: 12,
-        },
-        Slider: {
-            handleSize: 12,
         },
     },
 };

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -1,4 +1,3 @@
-// theme.ts
 import type { ThemeConfig } from "antd";
 import { theme } from "antd";
 

--- a/src/style/themeRoot.tsx
+++ b/src/style/themeRoot.tsx
@@ -1,20 +1,24 @@
 import { ConfigProvider } from "antd";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { darkTheme, lightTheme } from "./theme";
 
 export function ThemeRoot({ children }: { children: React.ReactNode }) {
     const [isDark, setIsDark] = useState(
-        () => window.matchMedia?.("(prefers-color-scheme: dark)").matches
+        () =>
+            window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false
     );
+
     useEffect(() => {
         const mq = window.matchMedia?.("(prefers-color-scheme: dark)");
+        if (!mq) return;
         const on = (e: MediaQueryListEvent) => setIsDark(e.matches);
-        mq?.addEventListener?.("change", on);
-        return () => mq?.removeEventListener?.("change", on);
+        mq.addEventListener?.("change", on);
+        return () => mq.removeEventListener?.("change", on);
     }, []);
-    const themeConfig = useMemo(
-        () => (isDark ? darkTheme : lightTheme),
-        [isDark]
+
+    return (
+        <ConfigProvider theme={isDark ? darkTheme : lightTheme}>
+            {children}
+        </ConfigProvider>
     );
-    return <ConfigProvider theme={themeConfig}>{children}</ConfigProvider>;
 }

--- a/src/style/themeRoot.tsx
+++ b/src/style/themeRoot.tsx
@@ -1,0 +1,20 @@
+import { ConfigProvider } from "antd";
+import { useState, useEffect, useMemo } from "react";
+import { darkTheme, lightTheme } from "./theme";
+
+export function ThemeRoot({ children }: { children: React.ReactNode }) {
+    const [isDark, setIsDark] = useState(
+        () => window.matchMedia?.("(prefers-color-scheme: dark)").matches
+    );
+    useEffect(() => {
+        const mq = window.matchMedia?.("(prefers-color-scheme: dark)");
+        const on = (e: MediaQueryListEvent) => setIsDark(e.matches);
+        mq?.addEventListener?.("change", on);
+        return () => mq?.removeEventListener?.("change", on);
+    }, []);
+    const themeConfig = useMemo(
+        () => (isDark ? darkTheme : lightTheme),
+        [isDark]
+    );
+    return <ConfigProvider theme={themeConfig}>{children}</ConfigProvider>;
+}


### PR DESCRIPTION
Problem
=======
Advances #84 

Solution
========
This PR adds a theme provider for antd, simplifies global styling where possible, and introduces media queries to check for the user's preferences on dark vs light theme.

No manual option to set the theme is provided.

I didn't cross reference with any design files so the styling dtails here need to be updated/confirmed, but as a template for dark/light mode and use of antd theming, this works.

As for global styling, while theming mostly covers colors, I noticed some odd spacing and overflow here and there so I tried to tighten up the layout a bit.

For starters there was a `Footer` component with no content, and fixed dimension, which was leading to overflow, so I just removed it.

Also the `.app-container` wraps everything, so I didn't see the purpose of having `display: flex` also set on `body` so I changed it to `display: block` and removed the min height and width.

* New feature (non-breaking change which adds functionality)

<img width="1431" height="686" alt="Screenshot 2025-09-23 at 1 47 56 PM" src="https://github.com/user-attachments/assets/f9cf28f5-ae8e-48a2-b48f-abd185db23bc" />
<img width="1427" height="676" alt="Screenshot 2025-09-23 at 1 47 41 PM" src="https://github.com/user-attachments/assets/f1de7168-87e8-4936-95a8-02aa0bd73c4d" />

