### PR TITLE
swap render order of recipe form and json viewer

### DIFF
--- a/src/components/PackingInput/index.tsx
+++ b/src/components/PackingInput/index.tsx
@@ -99,12 +99,6 @@ const PackingInput = (props: PackingInputProps): JSX.Element => {
                 />
             </div>
             <div className="recipe-content">
-                <JSONViewer
-                    title="Recipe"
-                    content={recipeStr}
-                    isEditable={fieldsToDisplay === undefined}
-                    onChange={setRecipeStr}
-                />
                 <RecipeForm
                     submitEnabled={submitEnabled}
                     recipeId={selectedRecipeId}
@@ -112,6 +106,12 @@ const PackingInput = (props: PackingInputProps): JSX.Element => {
                     submitPacking={runPacking}
                     changeHandler={handleFormChange}
                     getCurrentValue={getCurrentValue}
+                />
+                <JSONViewer
+                    title="Recipe"
+                    content={recipeStr}
+                    isEditable={fieldsToDisplay === undefined}
+                    onChange={setRecipeStr}
                 />
             </div>
         </div>


### PR DESCRIPTION
Swap the left/right order of the json view and the recipe form.


* New feature (non-breaking change which adds functionality)

<img width="1737" height="718" alt="Screenshot 2025-10-01 at 3 41 44 PM" src="https://github.com/user-attachments/assets/84df7fc3-3b2c-4ab9-8332-7b69022f8d8d" />
