### PR TITLE
Firebase Cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ function App() {
         }
         recipeJson[FIRESTORE_FIELDS.RECIPE_PATH] = path;
         recipeJson[FIRESTORE_FIELDS.NAME] = id;
+        recipeJson[FIRESTORE_FIELDS.TIMESTAMP] = Date.now();
         return recipeJson;
     }
 

--- a/src/constants/firebase.ts
+++ b/src/constants/firebase.ts
@@ -13,7 +13,6 @@ export const FIRESTORE_COLLECTIONS = {
     OBJECTS: "objects",
     GRADIENTS: "gradients",
     COMPOSITION: "composition",
-    EXAMPLE_RECIPES: "example_recipes",
     EDITED_RECIPES: "recipes_edited",
     JOB_STATUS: "job_status",
     PACKING_INPUTS: "example_packings",


### PR DESCRIPTION
Problem
=======
I was working on [this ticket](https://github.com/mesoscope/cellpack-client/issues/106) and came across two tiny code changes that we need to do

1. We aren't reading from the `example_recipes` collection anywhere, so I deleted it. However, I didn't want to leave the constant behind indicating that it existed, despite it not being used anywhere, so we're deleting that here
2. Ruge wrote [this lovely cleanup script](https://github.com/mesoscope/cellpack-client/blob/main/src/utils/firebase.ts#L190-L215) to prevent our database from becoming filled with bunches of old job statuses and edited recipes we don't need anymore. It checks timestamps to make sure that it's not deleting anything that might still be in use. One problem, we aren't putting timestamps in when we're uploading to edited_recipes, so none of those are getting deleted. This adds in the timestamp

