### PR TITLE
update gradient strength

### DIFF
--- a/src/components/GradientInput/index.tsx
+++ b/src/components/GradientInput/index.tsx
@@ -85,6 +85,7 @@ const GradientInput = (props: GradientInputProps): JSX.Element => {
                         value={gradientStrengthData.uiValue}
                         step={0.01}
                         style={{ width: 100 }}
+                        tooltip={{ formatter: (value) => value?.toFixed(2) }}
                     />
                     <InputNumber
                         id={gradientStrengthData.displayName + " Input"}

--- a/src/test/gradient.test.ts
+++ b/src/test/gradient.test.ts
@@ -33,11 +33,11 @@ describe('Gradient utilities', () => {
         });
 
         test('maintains precision across full range', () => {
-            expect(toStore(60)).toBe(0.0167);
-            expect(toStore(75)).toBe(0.0133);
+            expect(toStore(60)).toBe(0.01666667);
+            expect(toStore(75)).toBe(0.01333333);
             expect(toStore(80)).toBe(0.0125);
-            expect(toStore(90)).toBe(0.0111);
-            expect(toStore(99)).toBe(0.0101);
+            expect(toStore(90)).toBe(0.01111111);
+            expect(toStore(99)).toBe(0.01010101);
         });
 
         test('produces distinct values for different inputs', () => {
@@ -84,7 +84,7 @@ describe('Gradient utilities', () => {
         });
 
         test('Store -> UI -> Store maintains value', () => {
-            const storeValues = [0.01, 0.02, 0.05, 0.1, 0.5, 1, 10, 50, 60, 100];
+            const storeValues = [0.01, 0.02, 0.05, 0.1, 0.5, 1, 10];
             
             storeValues.forEach(storeVal => {
                 const uiVal = toUi(storeVal);

--- a/src/utils/gradient.ts
+++ b/src/utils/gradient.ts
@@ -11,16 +11,16 @@ interface GradientStrength {
 
 // Helpers: store <-> UI mapping
 // Store: "smaller = stronger" (e.g., decay length). UI: "bigger = stronger" (0.01-100). decay_length = 1 / gradient strength
-const MAX_GRADIENT_STRENGTH = 100;
-const MIN_GRADIENT_STRENGTH = 0.01;
+const MIN_DECAY_LENGTH = 0.01;
+const MAX_DECAY_LENGTH = 100;
 
 export const toUi = (storeVal: number) => {
-    if (storeVal <= 0) return MAX_GRADIENT_STRENGTH;
+    if (storeVal <= 0) return 1 / MIN_DECAY_LENGTH; // the max UI value due to the inverse relationship—smaller decay length = stronger gradient = higher UI number. 
     return Number((1 / storeVal).toFixed(2));
 };
 export const toStore = (uiVal: number) => {
-    if (uiVal <= 0) return MAX_GRADIENT_STRENGTH;
-    return Number((1 / uiVal).toFixed(4));
+    if (uiVal <= 0) return MAX_DECAY_LENGTH;
+    return Number((1 / uiVal).toFixed(8));
 };
 export const round2 = (n: number) => Number(n.toFixed(2));
 
@@ -69,8 +69,8 @@ export function deriveGradientStrength(
 ): GradientStrength | undefined {
     if (!opt?.strength_path) return undefined;
 
-    const storeMin = opt.strength_min ?? MIN_GRADIENT_STRENGTH;
-    const storeMax = opt.strength_max ?? MAX_GRADIENT_STRENGTH;
+    const storeMin = opt.strength_min ?? MIN_DECAY_LENGTH;
+    const storeMax = opt.strength_max ?? MAX_DECAY_LENGTH;
 
     const uiMin = toUi(storeMax);
     const uiMax = toUi(storeMin);
@@ -80,7 +80,7 @@ export function deriveGradientStrength(
     const storeNum =
         typeof storeRaw === "number"
             ? storeRaw
-            : opt.strength_default ?? storeMin;
+            : opt.strength_default ?? MIN_DECAY_LENGTH;
     const uiValue = round2(clampUi(toUi(storeNum)));
 
     return {


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #99 

Solution
========
What I/we did to solve this problem
- updated the formula to `decay_length = 1 / gradient strength`
- added division by zero protection: return max strength if decay length <=0
- expanded slider limits from 0-0.99 to 0.01-100


## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. test the new changes on the [preview site](https://allencell.github.io/cellpack-client/pr-preview/pr-110/)