### PR TITLE
display optional top-level data randomness_seed

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -144,6 +144,7 @@ export interface FirebaseRecipe {
     bounding_box?: [][] | object;
     grid_file_path?: string;
     recipe_path?: string;
+    randomness_seed?: number;
     composition?: Dictionary<FirebaseComposition>;
     objects?: Dictionary<FirebaseObject>;
     gradients?: Dictionary<FirebaseGradient>;
@@ -162,6 +163,7 @@ export type ViewableRecipe = {
     format_version?: string;
     bounding_box?: [][] | object;
     grid_file_path?: string;
+    randomness_seed?: number;
     composition?: Dictionary<ViewableComposition>;
     objects?: Dictionary<ViewableObject>;
     gradients?: Dictionary<ViewableGradient>;

--- a/src/utils/recipeLoader.ts
+++ b/src/utils/recipeLoader.ts
@@ -155,6 +155,7 @@ const recipeToViewable = (recipe: FirebaseRecipe): ViewableRecipe => {
         format_version: recipe.format_version,
         bounding_box: recipe.bounding_box,
         grid_file_path: recipe.grid_file_path,
+        randomness_seed: recipe.randomness_seed,
         composition: convertCollectionToViewable(recipe.composition),
         objects: convertCollectionToViewable(recipe.objects),
         gradients: convertCollectionToViewable(recipe.gradients),


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
`randomness_seed` is missing in `endosome_v_gradient_packing
 ` recipe data, need to display it in the UI

Solution
========
What I/we did to solve this problem
- added the field in the backend, change merged via [pr](https://github.com/mesoscope/cellpack/pull/416)
- **manually** updated the field in firebase doc, the automated upload script is in [pr](https://github.com/mesoscope/cellpack/pull/417/files). 
- **in this branch** added `randomness_seed` to the recipe type and display data

<img width="553" height="407" alt="Screenshot 2025-10-27 at 1 12 37 PM" src="https://github.com/user-attachments/assets/bdff1668-fe6b-462a-a25c-3a1a661915c8" />

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)
