### PR TITLE
handle case of no gradient

### DIFF
--- a/src/utils/gradient.ts
+++ b/src/utils/gradient.ts
@@ -46,6 +46,11 @@ export function getSelectedGradient(
     const validOptions =
         gradientOptions.filter(o => o.packing_mode === currentMode);
 
+    if (!validOptions.length) {
+        // Fallback to default if no valid options
+        return { currentGradient: defaultValue, selectedOption: { value: defaultValue, display_name: defaultValue, path: "" } as GradientOption };
+    }
+
     // Shared selector path (all options for this control share it)
     const selectorPath = gradientOptions[0].path ?? "";
 


### PR DESCRIPTION
Problem
=======
Right now, if you select "No Gradient" from the gradient dropdown, it fails to show up as the selected option in the input fields form. 
[Ticket](https://github.com/AllenCell/cellpack-client/issues/145)

Solution
========
I did verify that the recipe JSON was being updated appropriately when the user selects "No Gradient", so all I needed to change was how we're determining which gradient option is selected.

There are two parts of the recipe JSON that are updated based on recipe selection, the `gradient` field that is set to `membrane_gradient` or `nucleus_gradient` etc, and the `packing_mode` field which is either set to `random` for the "No Gradient" case or `gradient` for all other cases. We hadn't been looking at `packing_mode` when determining what gradient option is selected, but that's the only way to determine if "No Gradient" is selected, so I added some logic to check this field as well.
