### PR TITLE
Radius Rounding Bug

### DIFF
--- a/src/components/InputSwitch/index.tsx
+++ b/src/components/InputSwitch/index.tsx
@@ -78,7 +78,8 @@ const InputSwitch = (props: InputSwitchProps): JSX.Element => {
             const numericValue =
                 typeof value === "number" ? value : Number(value) || 0;
             const step = dataType === "integer" ? 1 : 0.01;
-            const maxValue = (max ?? 1) * conversion;
+            let maxValue = (max ?? 1) * conversion;
+            maxValue = Number(maxValue.toFixed(4));
 
             return (
                 <div className="input-switch">


### PR DESCRIPTION
Problem
=======
Rounding was behaving weirdly when you typed in a value [see ticket](https://github.com/AllenCell/cellpack-client/issues/129)

Solution
========
Since the radius is converted from micrometers in the input field to voxels in the recipe JSON, we getting some floats back with a lot of figures after the decimal point. Simply clamping the number of figures and rounding seemed to fix the problem.

I also added `type="number"`, which just prevents people from entering non-numbers into the little input box next to the slider