### PR TITLE
Oops - we broke the tests!

### DIFF
--- a/src/test/recipeLoader.test.ts
+++ b/src/test/recipeLoader.test.ts
@@ -74,8 +74,8 @@ test('one_sphere recipe displays correct default values', async () => {
     expect(recipe.version).toBe('1.0.0');
     expect(recipe.format_version).toBe('2.1');
     expect(recipe.bounding_box).toEqual([
-        [0, 0, 0],
-        [20, 20, 20]
+        [-20, -20, -20],
+        [100, 100, 100]
     ]);
     
     expect(recipe.objects?.base?.packing_mode).toBe('random');
@@ -84,7 +84,7 @@ test('one_sphere recipe displays correct default values', async () => {
     expect(recipe.objects?.base?.rejection_threshold).toBe(50);
     
     expect(recipe.objects?.sphere_25?.type).toBe('single_sphere');
-    expect(recipe.objects?.sphere_25?.radius).toBe(5);
+    expect(recipe.objects?.sphere_25?.radius).toBe(40);
     expect(recipe.objects?.sphere_25?.inherit).toBe('base');
     
     expect(recipe.composition?.A?.count).toBe(1);

--- a/src/test/test-files/one_sphere.json
+++ b/src/test/test-files/one_sphere.json
@@ -4,14 +4,14 @@
     "name": "one_sphere",
     "bounding_box": [
         [
-            0,
-            0,
-            0
+            -20,
+            -20,
+            -20
         ],
         [
-            20,
-            20,
-            20
+            100,
+            100,
+            100
         ]
     ],
     "objects": {
@@ -69,7 +69,7 @@
                 0.5,
                 0.5
             ],
-            "radius": 5,
+            "radius": 40,
             "representations": {
                 "mesh": null,
                 "atomic": null,


### PR DESCRIPTION
Problem
=======
Ruge and I updated the one-sphere example in firebase today to match with the new version of the recipe that's zoomed in better that we're displaying by default.

I forgot we had tests making sure we're unpacking recipes properly and using the one-sphere recipe as an example, which needs to be updated if the one-sphere firebase recipe is changed.

Solution
========
Updating the one-sphere recipe loading tests to match with the changes we made in firebase today
