### PR TITLE
Remove Content-Type header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,8 +72,7 @@ function App() {
 
         const url = getSubmitPackingUrl(firebaseRecipe, firebaseConfig);
         const requestBody = recipeChanged ? recipeString : undefined;
-        const headers = requestBody ? { "Content-Type": "application/json" } : undefined;
-        const request: RequestInfo = new Request(url, { method: "POST", body: requestBody, headers });
+        const request: RequestInfo = new Request(url, { method: "POST", body: requestBody });
         start = Date.now();
         const response = await fetch(request);
         setJobStatus(JOB_STATUS.SUBMITTED);


### PR DESCRIPTION
Problem
=======
Right now on staging, we're getting this CORS error:
<img width="527" height="64" alt="Screenshot 2026-04-14 at 9 32 44 AM" src="https://github.com/user-attachments/assets/639767a7-0859-4db4-8688-f5932ca20379" />

Solution
========
What I really want to do is go in to AWS API Gateway and adjust the CORS policy to allow for the Content-Type header, but everytime I do that I get a "network error" and it won't go through. I vaguely remember it being tricky to adjust the CORS policy previously, perhaps due to my lack of AWS permissions, although that's not indicated based on the error message, so I'm not really sure.

Technically, the Content-Type header is optional in this case, so it seems fine to just pull it out from the request itself? This did seem to resolve the problem for me.
