### PR TITLE
code cleanup: remove recipes_edited

### DIFF
--- a/src/constants/firebase.ts
+++ b/src/constants/firebase.ts
@@ -12,7 +12,6 @@ export const FIRESTORE_COLLECTIONS = {
     OBJECTS: "objects",
     GRADIENTS: "gradients",
     COMPOSITION: "composition",
-    EDITED_RECIPES: "recipes_edited",
     JOB_STATUS: "job_status",
     PACKING_INPUTS: "example_packings",
     EDITABLE_FIELDS: "editable_fields",
@@ -41,7 +40,6 @@ export const FIRESTORE_FIELDS = {
 
 export const RETENTION_POLICY = {
     RETENTION_PERIODS: {
-        RECIPES_EDITED: 24 * 60 * 60 * 1000, // 24 hours
         JOB_STATUS: 30 * 24 * 60 * 60 * 1000, // 30 days
     },
 

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -222,10 +222,6 @@ const docCleanup = async () => {
     const now = Date.now();
     const collectionsToClean = [
         {
-            name: FIRESTORE_COLLECTIONS.EDITED_RECIPES,
-            retention: RETENTION_POLICY.RETENTION_PERIODS.RECIPES_EDITED,
-        },
-        {
             name: FIRESTORE_COLLECTIONS.JOB_STATUS,
             retention: RETENTION_POLICY.RETENTION_PERIODS.JOB_STATUS,
         },


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
follow-up to the [server change](https://github.com/mesoscope/cellpack/pull/419)

The `recipes_edited` collection is no longer used, but there were still references to it across the repo.

Solution
========
What I/we did to solve this problem

removed remaining references to the `recipes_eidted` collection, including:
    - constants
    - retention policy
    - cleanup entry 
    

## Type of change
Please delete options that are not relevant.

* Code cleanup (non-breaking change which preserves existing functionality)
